### PR TITLE
Don't call onSuccess(api) if error occurred.

### DIFF
--- a/src/main/java/io/prismic/android/FetchApiTask.java
+++ b/src/main/java/io/prismic/android/FetchApiTask.java
@@ -35,7 +35,9 @@ public class FetchApiTask extends AsyncTask<String, Void, Api> {
 
   @Override
   protected void onPostExecute(Api api) {
-    listener.onSuccess(api);
+    if (api != null) {
+      listener.onSuccess(api);
+    }
   }
 
 }


### PR DESCRIPTION
You call onSuccess with the null Api reference, which is quite puzzling.
