### PR TITLE
Don't call onSuccess(null)

### DIFF
--- a/src/main/java/io/prismic/android/FetchApiTask.java
+++ b/src/main/java/io/prismic/android/FetchApiTask.java
@@ -27,7 +27,6 @@ public class FetchApiTask extends AsyncTask<String, Void, Api> {
     } catch (Exception e) {
       Log.e("prismic", "Error fetching API", e);
       e.printStackTrace();
-      e.printStackTrace();
       listener.onError(new Api.Error(Api.Error.Code.UNEXPECTED, "Error fetching API"));
       return null;
     }

--- a/src/main/java/io/prismic/android/SearchTask.java
+++ b/src/main/java/io/prismic/android/SearchTask.java
@@ -1,6 +1,8 @@
 package io.prismic.android;
 
 import android.os.AsyncTask;
+import android.util.Log;
+
 import io.prismic.Api;
 import io.prismic.Form;
 import io.prismic.Response;
@@ -19,6 +21,8 @@ public class SearchTask extends AsyncTask<Form.SearchForm, Void, Response> {
     try {
       return search.submit();
     } catch (Exception e) {
+      Log.e("prismic", "Error searching", e);
+      e.printStackTrace();
       listener.onError(new Api.Error(Api.Error.Code.UNEXPECTED, "Error searching"));
       return null;
     }

--- a/src/main/java/io/prismic/android/SearchTask.java
+++ b/src/main/java/io/prismic/android/SearchTask.java
@@ -26,7 +26,9 @@ public class SearchTask extends AsyncTask<Form.SearchForm, Void, Response> {
 
   @Override
   protected void onPostExecute(Response result) {
-    listener.onSuccess(result);
+    if (result != null) {
+      listener.onSuccess(result);
+    }
   }
 
 }


### PR DESCRIPTION
Ensures that SearchTask doesn't call onSuccess(null).

Adds additional logging to SearchTask.
